### PR TITLE
feat: Add Portuguese readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 > [!NOTE]
 > I accept help to make the version of the other programming languages.
 
+> [🇧🇷 Leia em Português](README.pt.md)
+
 # Multiform-validator
 
 Multiform-validator is a comprehensive, multilanguage library designed to validate various form fields. It supports validation for fields such as email, phone, password, CPF (Brazilian Individual Taxpayer Registry), credit card numbers, and more, ensuring data integrity and security across different programming languages.

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,38 @@
+> [!NOTE]
+> Aceito ajuda para fazer a versão de outras linguagens de programação.
+
+# Multiform-validator
+
+Multiform-validator é uma biblioteca abrangente e multilíngue projetada para validar vários campos de formulário. Ele suporta validação para campos como e-mail, telefone, senha, CPF (Cadastro de Pessoa Física), números de cartão de crédito e muito mais, garantindo a integridade e segurança dos dados em diferentes linguagens de programação.
+
+## Linguagens Suportadas
+
+Esta biblioteca fornece funcionalidades de validação nas seguintes linguagens de programação:
+
+- [TypeScript (TS/JS/NPM)](https://github.com/gabriel-logan/multiform-validator/tree/main/packages/typescript/README.md) (estável)
+- [Java](https://github.com/gabriel-logan/multiform-validator/tree/main/packages/java/README.md) (em breve)
+- [C#](https://github.com/gabriel-logan/multiform-validator/tree/main/packages/csharp/README.md) (em breve)
+- [Python](https://github.com/gabriel-logan/multiform-validator/tree/main/packages/python/README.md) (estável)
+- [PHP](https://github.com/gabriel-logan/multiform-validator/tree/main/packages/php/README.md) (em breve)
+
+## Uso
+
+Para instruções detalhadas de uso, consulte o arquivo README no diretório da linguagem de programação que você está usando. Por exemplo, os usuários de TypeScript podem encontrar as instruções de uso no [README do TypeScript](https://github.com/gabriel-logan/multiform-validator/tree/main/packages/typescript/README.md).
+
+## Instalação
+
+As instruções de instalação estão disponíveis no arquivo README do diretório da respectiva linguagem de programação.
+
+## Contribuindo
+
+Aceitamos contribuições! Por favor, consulte as diretrizes de contribuição antes de começar.
+
+## Contribuidores
+
+<a style="display: flex; justify-content: center;" href="https://github.com/gabriel-logan/multiform-validator/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=gabriel-logan/multiform-validator" />
+</a>
+
+## Licença
+
+Este projeto é licenciado sob a Licença MIT.


### PR DESCRIPTION
Related to #13

Add a Portuguese version of the README file.

* **README.pt.md**: Add a new file with the Portuguese translation of the existing `README.md` file.
* **README.md**: Add a link to the Portuguese version at the top of the file with a note indicating the availability of the Portuguese translation.


---